### PR TITLE
WEB-79: Frontend Google Sign-in

### DIFF
--- a/client/.env-example
+++ b/client/.env-example
@@ -1,1 +1,2 @@
 API_URL=http://localhost:5000/api
+GOOGLE_SIGNIN_CLIENT=

--- a/client/README.md
+++ b/client/README.md
@@ -66,7 +66,7 @@ The following components are included for Google Sign-in support:
 - App: App is always included, but the version for Google Sign-in includes
   application-level state that tracks the user's authentication status.
 - GoogleLoginButton: A class component that handles the sign-in/out actions. It
-  accepts callbacks as props to update the application-level status in App.
+  accepts callbacks as props to update the application-level state in App.
 - Login: A stateless component to be rendered when an unauthenticated user
   attempts to view a private route.
 
@@ -79,8 +79,7 @@ component.
 Public and private routes have been set up to be as simple as possible. By
 leveraging the application state, private routes are conditionally rendered. To
 add more public or private routes, simply add more routes to their respective
-`switch`es in `Routes.js`. New routes are automatically included in
-`BrowserRouter`.
+`Switch`es in `Routes.js`. New routes are automatically included in `App`.
 
 ### Linting and Formatting
 

--- a/client/README.md
+++ b/client/README.md
@@ -44,6 +44,44 @@ The following sample components are provided:
 - NotFound: A stateless component used as the fall-through if no other routes
   are matched.
 
+### Google Sign-in Support
+
+#### Setup
+
+Some quick POCs may require an integration with Google Sign-in. This support is
+toggled off by default, but it can be easily enabled in the `App` component.
+
+Past projets have been set up on [Google Developer
+Console](https://console.developers.google.com/), so you may be able to reach
+out for an existing `client_id`. This value is required to be set in the `.env`
+as `GOOGLE_SIGNIN_CLIENT`.
+
+If you are not able to acquire an existing `client_id` or would prefer to set
+up your own, simply create a Google Developer Console project and configure an
+"OAuth consent screen" to generate a valid `client_id`.
+
+#### Components
+
+The following components are included for Google Sign-in support:
+- App: App is always included, but the version for Google Sign-in includes
+  application-level state that tracks the user's authentication status.
+- GoogleLoginButton: A class component that handles the sign-in/out actions. It
+  accepts callbacks as props to update the application-level status in App.
+- Login: A stateless component to be rendered when an unauthenticated user
+  attempts to view a private route.
+
+When Google Sign-in is not needed, please remove the `GoogleLoginButton` and
+`Login` components. You should also prefer the stateless version of the `App`
+component.
+
+#### Routing
+
+Public and private routes have been set up to be as simple as possible. By
+leveraging the application state, private routes are conditionally rendered. To
+add more public or private routes, simply add more routes to their respective
+`switch`es in `Routes.js`. New routes are automatically included in
+`BrowserRouter`.
+
 ### Linting and Formatting
 
 This project has been pre-configured with Prettier and ESLint to work with the

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -19,8 +19,9 @@ const App = !USE_GOOGLE_SIGNIN
       </BrowserRouter>
     )
   : // Stateful component for Google Sign-in support
+    // Remove if not using Google Sign-in
     class App extends Component {
-      state = { isAuthenticated: false };
+      state = { isAuthenticated: false, authComplete: false, idToken: null };
 
       componentDidMount() {
         if (process.env.GOOGLE_SIGNIN_CLIENT === "") {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -9,7 +9,7 @@ import { GoogleLoginButton } from "@/components/GoogleLoginButton";
 // NOTE: Hot module replacement causes the button to disappear.
 //       This is not a problem when the app is built "normally."
 //       Refresh the browser to see the button again.
-const USE_GOOGLE_SIGNIN = true;
+const USE_GOOGLE_SIGNIN = false;
 
 const App = !USE_GOOGLE_SIGNIN
   ? // Simple Stateless component

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,13 +3,13 @@ import { BrowserRouter } from "react-router-dom";
 import { PublicRoutes, PrivateRoutes } from "@/Routes";
 import "@/styles/index.scss";
 
-import GoogleLoginButton from "@/components/GoogleLoginButton.js";
+import { GoogleLoginButton } from "@/components/GoogleLoginButton";
 
-// Easily toggle on Google Sign-in
+// Toggle on Google Sign-in
 // NOTE: Hot module replacement causes the button to disappear.
 //       This is not a problem when the app is built "normally."
 //       Refresh the browser to see the button again.
-const USE_GOOGLE_SIGNIN = false;
+const USE_GOOGLE_SIGNIN = true;
 
 const App = !USE_GOOGLE_SIGNIN
   ? // Simple Stateless component

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,12 +1,77 @@
-import React from "react";
+import React, { Component } from "react";
 import { BrowserRouter } from "react-router-dom";
-import Routes from "@/Routes";
+import { PublicRoutes, PrivateRoutes } from "@/Routes";
 import "@/styles/index.scss";
 
-const App = () => (
-  <BrowserRouter>
-    <Routes />
-  </BrowserRouter>
-);
+import GoogleLoginButton from "@/components/GoogleLoginButton.js";
+
+// Easily toggle on Google Sign-in
+// NOTE: Hot module replacement causes the button to disappear.
+//       This is not a problem when the app is built "normally."
+//       Refresh the browser to see the button again.
+const USE_GOOGLE_SIGNIN = false;
+
+const App = !USE_GOOGLE_SIGNIN
+  ? // Simple Stateless component
+    () => (
+      <BrowserRouter>
+        <PrivateRoutes />
+      </BrowserRouter>
+    )
+  : // Stateful component for Google Sign-in support
+    class App extends Component {
+      state = { isAuthenticated: false };
+
+      componentDidMount() {
+        if (process.env.GOOGLE_SIGNIN_CLIENT === "") {
+          console.error("Please add a valid GOOGLE_SIGNIN_CLIENT to .env");
+          return;
+        }
+        this.setupGoogleLogin();
+      }
+
+      setupGoogleLogin = () => {
+        window.gapi.load("auth2", () => {
+          const auth2 = window.gapi.auth2.init({
+            client_id: process.env.GOOGLE_SIGNIN_CLIENT,
+          });
+          this.handleAuthState(auth2.isSignedIn.get());
+          auth2.isSignedIn.listen(this.handleAuthState);
+        });
+      };
+
+      handleAuthState = value => {
+        // Abort subsequent invocations once authenticated
+        if (this.state.authComplete) {
+          return;
+        }
+
+        const authStatus =
+          value === undefined ? this.state.authStatus || false : value;
+        this.setState({
+          isAuthenticated: authStatus,
+          authComplete: true,
+          authStatus: value,
+        });
+      };
+
+      renderRoutes = () =>
+        this.state.isAuthenticated ? <PrivateRoutes /> : <PublicRoutes />;
+
+      render() {
+        return (
+          <div>
+            <GoogleLoginButton
+              setAuthenticationStatus={isAuthenticated =>
+                this.setState({ isAuthenticated })
+              }
+              setIdToken={idToken => this.setState({ idToken })}
+              isAuthenticated={this.state.isAuthenticated}
+            />
+            <BrowserRouter>{this.renderRoutes()}</BrowserRouter>
+          </div>
+        );
+      }
+    };
 
 export default App;

--- a/client/src/Routes.js
+++ b/client/src/Routes.js
@@ -3,8 +3,15 @@ import { Route, Switch } from "react-router-dom";
 import Home from "@/components/Home";
 import AboutUs from "@/components/AboutUs";
 import NotFound from "@/components/NotFound";
+import Login from "@/components/Login";
 
-const Routes = () => (
+const PublicRoutes = () => (
+  <Switch>
+    <Route component={Login} />
+  </Switch>
+);
+
+const PrivateRoutes = () => (
   <Switch>
     <Route exact path="/" component={Home} />
     <Route exact path="/about-us" component={AboutUs} />
@@ -12,4 +19,4 @@ const Routes = () => (
   </Switch>
 );
 
-export default Routes;
+export { PublicRoutes, PrivateRoutes };

--- a/client/src/components/AboutUs.js
+++ b/client/src/components/AboutUs.js
@@ -32,7 +32,7 @@ export default class AboutUs extends React.Component {
     return this.state.isLoading ? (
       <p>Loading...</p>
     ) : (
-      <p>{this.state.response}</p>
+      <p>Data fetched from API: {this.state.response}</p>
     );
   }
 

--- a/client/src/components/GoogleLoginButton.js
+++ b/client/src/components/GoogleLoginButton.js
@@ -1,8 +1,8 @@
 import React, { Component } from "react";
 
+// Component for handling Google Sign-in actions.
+// Remove if not using Google Sign-in
 export class GoogleLoginButton extends Component {
-  state = {};
-
   componentDidMount() {
     window.onSignIn = this.onSuccess;
   }

--- a/client/src/components/GoogleLoginButton.js
+++ b/client/src/components/GoogleLoginButton.js
@@ -1,0 +1,53 @@
+import React, { Component } from "react";
+
+export class GoogleLoginButton extends Component {
+  state = {};
+
+  componentDidMount() {
+    window.onSignIn = this.onSuccess;
+  }
+
+  signOut = () => {
+    const auth2 = window.gapi.auth2.getAuthInstance();
+    auth2.signOut().then(() => {
+      this.props.setAuthenticationStatus(false);
+    });
+  };
+
+  onSuccess = googleUser => {
+    // For more infomation:
+    // https://developers.google.com/identity/sign-in/web/sign-in
+    this.props.setAuthenticationStatus(true);
+    const idToken = googleUser.getAuthResponse().id_token;
+    this.props.setIdToken(idToken);
+  };
+
+  render() {
+    return (
+      <div>
+        <button
+          style={{
+            height: "36px",
+            width: "120px",
+            cursor: "pointer",
+            float: "right",
+            display: this.props.isAuthenticated ? "block" : "none",
+          }}
+          onClick={this.signOut}
+        >
+          Sign Out
+        </button>
+        <div
+          style={{
+            float: "right",
+            display: this.props.isAuthenticated ? "none" : "block",
+          }}
+          className="g-signin2"
+          data-onsuccess="onSignIn"
+        />
+      </div>
+    );
+  }
+}
+
+export default GoogleLoginButton;

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -1,0 +1,10 @@
+import React from "react";
+
+const Login = () => (
+  <div>
+    <h1>Welcome!</h1>
+    <p>Please Sign In</p>
+  </div>
+);
+
+export default Login;

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>React App</title>
+    <script src="https://apis.google.com/js/platform.js"></script>
   </head>
   <body>
     <noscript> You need to enable JavaScript to run this app. </noscript>

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -10,9 +10,11 @@ const PORT = process.env.PORT || 3000;
 const env = dotenv.config().parsed || {};
 
 const API_URL = env.API_URL || "http://localhost:5000/api";
+const GOOGLE_SIGNIN_CLIENT = env.GOOGLE_SIGNIN_CLIENT || "";
 
 const ENVIRONMENT_VARIABLES = {
   "process.env.API_URL": JSON.stringify(API_URL),
+  "process.env.GOOGLE_SIGNIN_CLIENT": JSON.stringify(GOOGLE_SIGNIN_CLIENT),
 };
 
 module.exports = [


### PR DESCRIPTION
Adds toggle-able support for Google Sign-in.
- Basic Public/Private routes
- Application-level state that tracks user's authentication state + session token
- Automatically "sign-in" authenticated users

The hope is that this implementation is as simple-to-understand/extend as possible. For example, there is no complexity around redirecting, and redux has not been added. This has drawbacks for a long-term project, but it should be beneficial for time-sensitive POCs.